### PR TITLE
xsbt-filter for SBT 0.12.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,4 @@
-libraryDependencies <+= sbtVersion("org.scala-sbt" %% "scripted-plugin" % _)
+libraryDependencies <+= sbtVersion(v => v.split('.') match {
+    case Array("0", "12", _) => "org.scala-sbt" % "scripted-plugin" % v
+    case _                   => "org.scala-sbt" %% "scripted-plugin" % v
+})


### PR DESCRIPTION
Apply @twittner's patch from sdb/xsbt-filter#6.

If you want to use xsbt-filter with SBT 0.12.0 before this pull request has been merged, you can use my forked repo by using the following code in `project/project/build.scala`:

``` scala
import sbt._

object PluginDef extends Build {
  override lazy val projects = Seq(root)
  lazy val root = Project("plugins", file(".")) dependsOn(xsbtFilterPlugin)
  lazy val xsbtFilterPlugin = uri("https://github.com/pvalkone/xsbt-filter.git#sbt_0.12.0")
}
```
