### PR TITLE
Support filtering via environment variables

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,3 +9,8 @@ seq(ScriptedPlugin.scriptedSettings: _*)
 scalaSource in Compile <<= baseDirectory { (base) => base / "src" }
 
 sbtTestDirectory <<= baseDirectory { (base) => base / "sbt-test" }
+
+crossScalaVersions := Seq("2.9.1", "2.9.2")
+
+scalacOptions ++= Seq("-deprecation", "-unchecked")
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,6 @@ libraryDependencies <+= sbtVersion(v => v.split('.') match {
     case Array("0", "12", _) => "org.scala-sbt" % "scripted-plugin" % v
     case _                   => "org.scala-sbt" %% "scripted-plugin" % v
 })
+
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.1.0")
+

--- a/src/FilterPlugin.scala
+++ b/src/FilterPlugin.scala
@@ -23,6 +23,7 @@ object Plugin extends sbt.Plugin {
     val extraProps = SettingKey[Seq[(String, String)]]("filter-extra-props", "Extra filter properties.")
     val projectProps = TaskKey[Seq[(String, String)]]("filter-project-props", "Project filter properties.")
     val systemProps = TaskKey[Seq[(String, String)]]("filter-system-props", "System filter properties.")
+    val envProps = TaskKey[Seq[(String, String)]]("filter-env-props", "Environment filter properties.")
     val managedProps = TaskKey[Seq[(String, String)]]("filter-managed-props", "Managed filter properties.")
     val unmanagedProps = TaskKey[Seq[(String, String)]]("filter-unmanaged-props", "Filter properties defined in filters.")
     val props = TaskKey[Seq[(String, String)]]("filter-props", "All filter properties.")
@@ -59,8 +60,8 @@ object Plugin extends sbt.Plugin {
     excludeFilter in filterResources := HiddenFileFilter || ImageFileFilter)
   lazy val filterConfigTasks: Seq[Setting[_]] = Seq(
     filterResourcesTask,
-    copyResources in filterResources <<= (copyResources).identity,
-    managedProps <<= (projectProps, systemProps) map (_ ++ _),
+    copyResources in filterResources <<= copyResources,
+    managedProps <<= (projectProps, systemProps, envProps) map (_ ++ _ ++ _),
     unmanagedPropsTask,
     props <<= (extraProps, managedProps, unmanagedProps) map (_ ++ _ ++ _))
   lazy val filterConfigSettings: Seq[Setting[_]] = filterConfigTasks ++ filterConfigPaths
@@ -69,6 +70,7 @@ object Plugin extends sbt.Plugin {
     filterDirectoryName := "filters",
     extraProps := Nil,
     projectPropsTask,
+    envProps := System.getenv.toSeq,
     systemProps := System.getProperties.stringPropertyNames.toSeq map (k => k -> System.getProperty(k)))
   lazy val filterSettings = baseFilterSettings ++ inConfig(Compile)(filterConfigSettings) ++ inConfig(Test)(filterConfigSettings)
 


### PR DESCRIPTION
Adds support for filtering via environment variables. 

Also, changes a few other things...
1. fixed deprecation warning
2. cross compiling for scala 2.9.1 and 2.9.2
